### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/svg-builder.cabal
+++ b/svg-builder.cabal
@@ -20,7 +20,7 @@ library
                        Graphics.Svg.Path,
                        Graphics.Svg.Elements,
                        Graphics.Svg.Attributes
-  build-depends:       base                  >= 4.5   && < 4.10,
+  build-depends:       base                  >= 4.5   && < 4.11,
                        blaze-builder         >= 0.4   && < 0.5,
                        bytestring            >= 0.10  && < 0.11,
                        hashable              >= 1.1   && < 1.3,


### PR DESCRIPTION
GHC 8.2 ships with base-4.10.
The package still builds after the bump.