### PR TITLE
Add a Semigroup Element instance

### DIFF
--- a/svg-builder.cabal
+++ b/svg-builder.cabal
@@ -31,5 +31,7 @@ library
                        hashable              >= 1.1   && < 1.3,
                        text                  >= 0.11  && < 1.3,
                        unordered-containers  >= 0.2 && < 0.3
+  if !impl(ghc >= 8.0)
+    build-depends:     semigroups            >= 0.16.1 && < 0.19
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This is needed to fix the build on GHC 8.4, where `Semigroup` is a superclass of `Monoid`.