### PR TITLE
bump base bounds

### DIFF
--- a/svg-builder.cabal
+++ b/svg-builder.cabal
@@ -24,7 +24,7 @@ library
                        Graphics.Svg.Path,
                        Graphics.Svg.Elements,
                        Graphics.Svg.Attributes
-  build-depends:       base                  >= 4.5   && < 4.12,
+  build-depends:       base                  >= 4.5   && < 4.13,
                        blaze-builder         >= 0.4   && < 0.5,
                        bytestring            >= 0.10  && < 0.11,
                        hashable              >= 1.1   && < 1.3,


### PR DESCRIPTION
Bumps bounds on `base` so it can be used with GHC 8.6.1. Among other things, this will enable building `diagrams-svg` with GHC 8.6.1