### PR TITLE
Elliptical Arc Curve

### DIFF
--- a/examples/heart.hs
+++ b/examples/heart.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Graphics.Svg
+import Data.Monoid
+import Data.Text.Lazy as T
+
+svg :: Element -> Element
+svg content =
+      doctype
+   <> with (svg11_ content) [Width_ <<- "100", Height_ <<- "100"]
+
+contents :: Element
+contents =path_
+  [ Stroke_ <<- "#FF0000"
+  , Fill_ <<- "none"
+  , D_ <<- (
+        mA 10 30
+      <> aA 20 20 0 0 1 50 30
+      <> aA 20 20 0 0 1 90 30
+      <> qA 90 60 50 90
+      <> qA 10 60 10 30
+      <> z
+      )
+  ]
+
+main :: IO ()
+main = do
+  print $ svg contents

--- a/examples/heart.svg
+++ b/examples/heart.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" height="100" width="100" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"><path d="M 10.0000,30.0000 A 20.0000,20.0000 0.0000 0 1 50.0000 30.0000 A 20.0000,20.0000 0.0000 0 1 90.0000 30.0000 Q 90.0000,60.0000 50.0000,90.0000 Q 10.0000,60.0000 10.0000,30.0000 Z" stroke="#FF0000" fill="none"/></svg>

--- a/src/Graphics/Svg/Path.hs
+++ b/src/Graphics/Svg/Path.hs
@@ -20,10 +20,14 @@ import qualified Data.Text                        as T
 import           Data.Text.Lazy                   (toStrict)
 import           Data.Text.Lazy.Builder           (toLazyText)
 import           Data.Text.Lazy.Builder.RealFloat
+import           Data.Text.Lazy.Builder.Int       (decimal)
 
 -- | Convert a number to Text.
 toText :: RealFloat a => a -> Text
 toText = toStrict . toLazyText . formatRealFloat Fixed (Just 4)
+
+toTextIntegral :: Integral a => a -> Text
+toTextIntegral = toStrict . toLazyText . decimal
 
 -- | moveto (absolute)
 mA :: RealFloat a =>  a -> a -> Text
@@ -98,16 +102,16 @@ tR :: RealFloat a =>  a -> a -> Text
 tR x y = T.concat [ "t ", toText x, ",", toText y, " "]
 
 -- | Arc (absolute)
-aA :: RealFloat a =>  a -> a -> a -> a -> a -> a -> a -> Text
+aA :: (RealFloat a, Integral b) =>  a -> a -> a -> b -> b -> a -> a -> Text
 aA rx ry xrot largeFlag sweepFlag x y = T.concat
-  [ "A ", toText rx, ",", toText ry, " ", toText xrot, " ", toText largeFlag
-  , " ", toText sweepFlag, " ", toText x, " ", toText y, " "]
+  [ "A ", toText rx, ",", toText ry, " ", toText xrot, " ", toTextIntegral largeFlag
+  , " ", toTextIntegral sweepFlag, " ", toText x, " ", toText y, " "]
 
 -- | Arc (relative)
-aR :: RealFloat a =>  a -> a -> a -> a -> a -> a -> a -> Text
+aR :: (RealFloat a, Integral b) =>  a -> a -> a -> b -> b -> a -> a -> Text
 aR rx ry xrot largeFlag sweepFlag x y = T.concat
-  [ "a ", toText rx, ",", toText ry, " ", toText xrot, " ", toText largeFlag
-  , " ", toText sweepFlag, " ", toText x, " ", toText y, " "]
+  [ "a ", toText rx, ",", toText ry, " ", toText xrot, " ", toTextIntegral largeFlag
+  , " ", toTextIntegral sweepFlag, " ", toText x, " ", toText y, " "]
 
 -- | closepath
 z :: Text


### PR DESCRIPTION

I was following the heart example on this page and found a bug with elliptical arc curve implementation.
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d

Consider the following translation into code.
```haskell
contents :: Element
contents = path_
  [ Stroke_ <<- "#FF0000"
  , Fill_ <<- "none"
  , D_ <<- (
         mA 10 30
      <> aA 20 20 0 0 1 50 30
      <> aA 20 20 0 0 1 90 30
      <> qA 90 60 50 90
      <> qA 10 60 10 30
      <> z
      )
  ]
```

Arcs don't display when a floating point representation is used for the large-arc-flag and sweep flags. This is the current output.
![heart_realfloat](https://user-images.githubusercontent.com/3070597/154182178-659ec868-f30e-45b2-8ef2-458b02375d94.svg)
```svg
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg xmlns="http://www.w3.org/2000/svg" height="100" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100">
<path fill="none" d="M 10.0000,30.0000 A 20.0000,20.0000 0.0000 0 1 50.0000 30.0000 A 20.0000,20.0000 0.0000 0 1 90.0000 30.0000 Q 90.0000,60.0000 50.0000,90.0000 Q 10.0000,60.0000 10.0000,30.0000 Z" stroke="#FF0000"/>
</svg>

```

This is how it should look, and this is what the PR outputs.
![heart_integral](https://user-images.githubusercontent.com/3070597/154182173-ba9cda6d-b9c6-4386-bf13-85d2785b4847.svg)
```svg
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg xmlns="http://www.w3.org/2000/svg" height="100" width="100" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
<path d="M 10.0000,30.0000 A 20.0000,20.0000 0.0000 0 1 50.0000 30.0000 A 20.0000,20.0000 0.0000 0 1 90.0000 30.0000 Q 90.0000,60.0000 50.0000,90.0000 Q 10.0000,60.0000 10.0000,30.0000 Z" stroke="#FF0000" fill="none"/>
</svg>
```