### PR TITLE
use faster Float/Double rendering from double-conversion

### DIFF
--- a/src/Graphics/Svg/Path.hs
+++ b/src/Graphics/Svg/Path.hs
@@ -17,94 +17,92 @@ module Graphics.Svg.Path where
 
 import           Data.Text                        (Text)
 import qualified Data.Text                        as T
-import           Data.Text.Lazy                   (toStrict)
-import           Data.Text.Lazy.Builder           (toLazyText)
-import           Data.Text.Lazy.Builder.RealFloat
+import           Data.Double.Conversion.Convertable (Convertable(toExponential))
 
 -- | Convert a number to Text.
-toText :: RealFloat a => a -> Text
-toText = toStrict . toLazyText . formatRealFloat Fixed (Just 4)
+toText :: Convertable a Text => a -> Text
+toText = toExponential 4
 
 -- | moveto (absolute)
-mA :: RealFloat a =>  a -> a -> Text
+mA :: Convertable a Text =>  a -> a -> Text
 mA x y = T.concat ["M " ,toText x, ",", toText y, " "]
 
 -- | moveto (relative)
-mR :: RealFloat a =>  a -> a -> Text
+mR :: Convertable a Text =>  a -> a -> Text
 mR dx dy = T.concat ["m ", toText dx, ",", toText dy, " "]
 
 -- | lineto (absolute)
-lA :: RealFloat a =>  a -> a -> Text
+lA :: Convertable a Text =>  a -> a -> Text
 lA x y = T.concat ["L ", toText x, ",", toText y, " "]
 
 -- | lineto (relative)
-lR :: RealFloat a =>  a -> a -> Text
+lR :: Convertable a Text =>  a -> a -> Text
 lR dx dy = T.concat ["l ", toText dx, ",", toText dy, " "]
 
 -- | horizontal lineto (absolute)
-hA :: RealFloat a =>  a -> Text
+hA :: Convertable a Text =>  a -> Text
 hA x = T.concat ["H ", toText x, " "]
 
 -- | horizontal lineto (relative)
-hR :: RealFloat a =>  a -> Text
+hR :: Convertable a Text =>  a -> Text
 hR dx = T.concat ["h ", toText dx, " "]
 
 -- | vertical lineto (absolute)
-vA :: RealFloat a =>  a -> Text
+vA :: Convertable a Text =>  a -> Text
 vA y = T.concat ["V ", toText y, " "]
 
 -- | vertical lineto (relative)
-vR :: RealFloat a =>  a -> Text
+vR :: Convertable a Text =>  a -> Text
 vR dy = T.concat ["v ", toText dy, " "]
 
 -- | Cubic Bezier curve (absolute)
-cA :: RealFloat a =>  a -> a -> a -> a -> a -> a -> Text
+cA :: Convertable a Text =>  a -> a -> a -> a -> a -> a -> Text
 cA c1x c1y c2x c2y x y = T.concat
   [ "C ", toText c1x, ",", toText c1y, " ", toText c2x, ","
   , toText c2y, " ", toText x, " ", toText y]
 
 -- | Cubic Bezier curve (relative)
-cR :: RealFloat a =>  a -> a -> a -> a -> a -> a -> Text
+cR :: Convertable a Text =>  a -> a -> a -> a -> a -> a -> Text
 cR dc1x dc1y dc2x dc2y dx dy = T.concat
   [ "c ", toText dc1x, ",", toText dc1y, " ", toText dc2x
   , ",", toText dc2y, " ", toText dx, " ", toText dy]
 
 -- | Smooth Cubic Bezier curve (absolute)
-sA :: RealFloat a =>  a -> a -> a -> a -> Text
+sA :: Convertable a Text =>  a -> a -> a -> a -> Text
 sA c2x c2y x y = T.concat
   ["S ", toText c2x, ",", toText c2y, " ", toText x, ",", toText y, " "]
 
 -- | Smooth Cubic Bezier curve (relative)
-sR :: RealFloat a =>  a -> a -> a -> a -> Text
+sR :: Convertable a Text =>  a -> a -> a -> a -> Text
 sR dc2x dc2y dx dy = T.concat
   ["s ", toText dc2x, ",", toText dc2y, " ", toText dx, ",", toText dy, " "]
 
 -- | Quadratic Bezier curve (absolute)
-qA :: RealFloat a =>  a -> a -> a -> a -> Text
+qA :: Convertable a Text =>  a -> a -> a -> a -> Text
 qA cx cy x y = T.concat
   ["Q ", toText cx, ",", toText cy, " ", toText x, ",", toText y, " "]
 
 -- | Quadratic Bezier curve (relative)
-qR :: RealFloat a =>  a -> a -> a -> a -> Text
+qR :: Convertable a Text =>  a -> a -> a -> a -> Text
 qR dcx dcy dx dy = T.concat
   ["q ", toText dcx, ",", toText dcy, " ", toText dx, ",", toText dy, " " ]
 
 -- | Smooth Quadratic Bezier curve (absolute)
-tA  :: RealFloat a =>  a -> a -> Text
+tA  :: Convertable a Text =>  a -> a -> Text
 tA x y = T.concat ["T ", " ", toText x, ",", toText y, " "]
 
 -- | Smooth Quadratic Bezier curve (relative)
-tR :: RealFloat a =>  a -> a -> Text
+tR :: Convertable a Text =>  a -> a -> Text
 tR x y = T.concat [ "t ", toText x, ",", toText y, " "]
 
 -- | Arc (absolute)
-aA :: RealFloat a =>  a -> a -> a -> a -> a -> a -> a -> Text
+aA :: Convertable a Text =>  a -> a -> a -> a -> a -> a -> a -> Text
 aA rx ry xrot largeFlag sweepFlag x y = T.concat
   [ "A ", toText rx, ",", toText ry, " ", toText xrot, " ", toText largeFlag
   , " ", toText sweepFlag, " ", toText x, " ", toText y, " "]
 
 -- | Arc (relative)
-aR :: RealFloat a =>  a -> a -> a -> a -> a -> a -> a -> Text
+aR :: Convertable a Text =>  a -> a -> a -> a -> a -> a -> a -> Text
 aR rx ry xrot largeFlag sweepFlag x y = T.concat
   [ "a ", toText rx, ",", toText ry, " ", toText xrot, " ", toText largeFlag
   , " ", toText sweepFlag, " ", toText x, " ", toText y, " "]
@@ -115,32 +113,32 @@ z = "Z"
 
 -- | SVG Transform components
 -- | Specifies a translation by @x@ and @y@
-translate :: RealFloat a =>  a -> a -> Text
+translate :: Convertable a Text =>  a -> a -> Text
 translate x y = T.concat ["translate(", toText x, " ", toText y, ")"]
 
 -- | Specifies a scale operation by @x@ and @y@
-scale :: RealFloat a =>  a -> a -> Text
+scale :: Convertable a Text =>  a -> a -> Text
 scale x y = T.concat ["scale(", toText x, " ", toText y, ")"]
 
 -- | Specifies a rotation by @rotate-angle@ degrees
-rotate :: RealFloat a =>  a -> Text
+rotate :: Convertable a Text =>  a -> Text
 rotate angle = T.concat ["rotate(", toText angle, ")"]
 
 -- | Specifies a rotation by @rotate-angle@ degrees about the given time @rx,ry@
-rotateAround :: RealFloat a =>  a -> a -> a -> Text
+rotateAround :: Convertable a Text =>  a -> a -> a -> Text
 rotateAround angle rx ry = T.concat
   ["rotate(", toText angle, ",", toText rx, ",", toText ry, ")"]
 
 -- | Skew tansformation along x-axis
-skewX :: RealFloat a =>  a -> Text
+skewX :: Convertable a Text =>  a -> Text
 skewX angle = T.concat ["skewX(", toText angle, ")"]
 
 -- | Skew tansformation along y-axis
-skewY :: RealFloat a =>  a -> Text
+skewY :: Convertable a Text =>  a -> Text
 skewY angle = T.concat ["skewY(", toText angle, ")"]
 
 -- | Specifies a transform in the form of a transformation matrix
-matrix :: RealFloat a =>  a -> a -> a -> a -> a -> a -> Text
+matrix :: Convertable a Text =>  a -> a -> a -> a -> a -> a -> Text
 matrix a b c d e f =  T.concat
   [ "matrix(", toText a, ",", toText b, ",",  toText c
   , ",",  toText d, ",", toText e, ",",  toText f, ")"]

--- a/svg-builder.cabal
+++ b/svg-builder.cabal
@@ -28,6 +28,7 @@ library
   build-depends:       base                  >= 4.5   && < 4.22,
                        blaze-builder         >= 0.4   && < 0.5,
                        bytestring            >= 0.10  && < 0.13,
+                       double-conversion     >= 2.0.2 && < 2.1,
                        hashable              >= 1.1   && < 1.6,
                        text                  >= 0.11  && < 2.2,
                        unordered-containers  >= 0.2 && < 0.3


### PR DESCRIPTION
This PR changes the Float/Double renderer to the one provided by `double-conversion`.  `double-conversion` wraps a modern C++ floating point rendering library (Loitsch, 2010) and is used by many other Haskell libraries including `aeson`.  The existing floating point renderer from `Data.text.Lazy.Builder.RealFloat` is antiquated (Burger and Dybvig, 1996) and implemented in pure Haskell.  Interesting discussion over [here](http://www.serpentine.com/blog/2011/06/29/here-be-dragons-advances-in-problems-you-didnt-even-know-you-had/)

I tested this implementation by generating a SVG with a 1,000 point path.
My Ryzen 9 3900x showed a 6x speedup.
My Intel Atom E3930 showed a 10x speedup.

I also changed the rendered format from fixed point 4 decimals to exponent format.  Fixed point format will fail if the SVG context is zoomed in such that more than 4 decimals are needed.  This kind of zooming is uncommon, but the SVG format allows it so `svg-builder` should allow it too.

My use case is an Intel Atom network appliance that continuously pushes generated SVGs through a Websocket to implement something like an oscilloscope.  CPU load was observed to be quite high, and this PR improved things immensely.

As a side note, `Convertible` supports Lazy Text Builder so I also experimented with composing the whole SVG path as a Builder and then rendering it to a strict Text.  To my surprise this was actually a bit slower than the solution in this PR.  Furthermore, the text builder in `double-conversion` had a [bug](https://github.com/haskell/double-conversion/issues/56).

